### PR TITLE
chore(core.cloud.command.test): Removed useless artemis dependency

### DIFF
--- a/tests/org.eclipse.kura.core.cloud.command.test/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.kura.core.cloud.command.test/META-INF/MANIFEST.MF
@@ -19,6 +19,4 @@ Import-Package: org.eclipse.kura.core.testutil,
  org.osgi.service.cm;version="1.4.0",
  org.slf4j;version="1.6.4"
 Fragment-Host: org.eclipse.kura.core.cloud.command
-Require-Bundle: org.eclipse.kura.broker.artemis.core;bundle-version="1.2.0",
- org.eclipse.kura.broker.artemis.simple.mqtt;bundle-version="1.1.0"
 


### PR DESCRIPTION
This pull request makes a minor update to the `META-INF/MANIFEST.MF` file for the `org.eclipse.kura.core.cloud.command.test` tests. It removes the `Require-Bundle` dependencies on `org.eclipse.kura.broker.artemis.core` and `org.eclipse.kura.broker.artemis.simple.mqtt`, likely as part of a cleanup or because these dependencies are no longer needed.