### PR TITLE
build: renaming bom dependencies to pde-deps

### DIFF
--- a/target-definition/kura-command.target
+++ b/target-definition/kura-command.target
@@ -22,13 +22,13 @@
             <dependencies>
                 <dependency>
                     <groupId>org.eclipse.kura</groupId>
-                    <artifactId>target-platform-bom</artifactId>
+                    <artifactId>target-platform-tycho-deps</artifactId>
                     <version>6.0.0-SNAPSHOT</version>
                     <type>pom</type>
                 </dependency>
                 <dependency>
                     <groupId>org.eclipse.kura</groupId>
-                    <artifactId>kura-bom</artifactId>
+                    <artifactId>kura-tycho-deps</artifactId>
                     <version>6.0.0-SNAPSHOT</version>
                     <type>pom</type>
                 </dependency>

--- a/target-definition/kura-command.target
+++ b/target-definition/kura-command.target
@@ -22,13 +22,13 @@
             <dependencies>
                 <dependency>
                     <groupId>org.eclipse.kura</groupId>
-                    <artifactId>target-platform-tycho-deps</artifactId>
+                    <artifactId>target-platform-pde-deps</artifactId>
                     <version>6.0.0-SNAPSHOT</version>
                     <type>pom</type>
                 </dependency>
                 <dependency>
                     <groupId>org.eclipse.kura</groupId>
-                    <artifactId>kura-tycho-deps</artifactId>
+                    <artifactId>kura-pde-deps</artifactId>
                     <version>6.0.0-SNAPSHOT</version>
                     <type>pom</type>
                 </dependency>


### PR DESCRIPTION
The POMs in the esf-bom and target-platform-bom projects in kura-core are not Maven BOM POMs according to the official Maven [documentation on the subject](https://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html#Bill_of_Materials_.28BOM.29_POMs): this can cause great confusion, especially since that is a Maven standard. Those projects were renamed in the kura-core repo, so the depencies here must be aligned.

This PR renames the projects and all their occurences in the framework like:

- kura-bom --> kura-pde-deps
- target-platform-bom --> target-platform-pde-deps